### PR TITLE
Updating generate script to be compatible with Windows filesystems

### DIFF
--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -11,6 +11,7 @@ import {
   DATASOURCES_CHUNK_SIZE,
   DATASOURCES_CHUNK_OVERLAP,
 } from "./constants.mjs";
+import { fileURLToPath } from 'url';
 import { exit } from "process";
 import dotenv from "dotenv";
 import path from "path";
@@ -47,10 +48,10 @@ async function generateDatasource(serviceContext, datasource) {
 
 async function ensureEnv(fileName) {
   try {
-    const __dirname = path.dirname(new URL(import.meta.url).pathname);
-    const envFileContent = await fs.promises.readFile(
-      path.join(__dirname, "..", fileName),
-    );
+    // Correctly determine the directory name
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const envFilePath = path.join(__dirname, "..", fileName);
+    const envFileContent = await fs.promises.readFile(envFilePath);
     const envConfig = dotenv.parse(envFileContent);
     if (envConfig && envConfig.OPENAI_API_KEY) {
       process.env.OPENAI_API_KEY = envConfig.OPENAI_API_KEY;


### PR DESCRIPTION
Updating generate script to be compatible with windows filesystems.

Previous code resulted in prefixing file path with an extra '\' character resulting in error:
![image](https://github.com/run-llama/chat-llamaindex/assets/79941788/c6d6e943-04dd-4732-afc4-5588134b91b7)
