### PR TITLE
Update Emoji CDN

### DIFF
--- a/app/components/ui/emoji.tsx
+++ b/app/components/ui/emoji.tsx
@@ -5,7 +5,7 @@ import EmojiPicker, {
 } from "emoji-picker-react";
 
 export function getEmojiUrl(unified: string, style: EmojiStyle) {
-  return `https://cdn.staticfile.org/emoji-datasource-apple/14.0.0/img/${style}/64/${unified}.png`;
+  return `https://cdnjs.cloudflare.com/ajax/libs/emoji-datasource-apple/15.0.1/img/${style}/64/${unified}.png`;
 }
 
 export function EmojiAvatarPicker(props: {


### PR DESCRIPTION
The previous CDN (cdn.staticfile.org) appears to no longer host emoji files. This commit updates the CDN to Cloudflare and incorporates the latest emoji versions.