### PR TITLE
fix: clear user input after chat submit

### DIFF
--- a/app/components/chat/chat-input.tsx
+++ b/app/components/chat/chat-input.tsx
@@ -155,6 +155,7 @@ export default function ChatInput(props: ChatInputProps) {
     if (isURL(input)) {
       setTemporaryURLInput(input);
     }
+    setUserInput("");
     await callLLM({ input, fileDetail: imageFile });
     if (!isMobileScreen) inputRef.current?.focus();
     setAutoScroll(true);


### PR DESCRIPTION
I noticed that after sending a msg the text input was not being cleared. I dont know if this is intentional, but if this is not: this PR clear the chat input after the msg is submitted.