### PR TITLE
fix: Docker ssh error (#89)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # ---- Build Stage ----
 FROM node:18-bookworm-slim AS build
 
+# Install ca-certificates. Issue: #89
+RUN apt-get update
+RUN apt-get install -y ca-certificates
+
 # Set the working directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The issue occurs due to the missing ca-certificates. Installing it solves the issue.
