### PR TITLE
fix: docker build fail on pnpm install with python error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM node:18-bookworm-slim AS build
 RUN apt-get update
 RUN apt-get install -y ca-certificates
 
+# Install Python, g++, and make for building native dependencies
+# Issue: https://github.com/docker/getting-started/issues/124
+RUN apt-get install -y python3 g++ make && \
+    apt-get clean
+
 # Set the working directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Fix issue https://github.com/run-llama/chat-llamaindex/issues/95
Related issue: https://github.com/docker/getting-started/issues/124
The cause may because MacBook with the M1 chip
To fix, install python before running pnpm install
Related solution: https://github.com/docker/getting-started/issues/124#issuecomment-779806159 